### PR TITLE
Correctly identify PATCH requests

### DIFF
--- a/src/httpbeast/parser.nim
+++ b/src/httpbeast/parser.nim
@@ -18,7 +18,7 @@ proc parseHttpMethod*(data: string, start: int): Option[HttpMethod] =
     if data[start+1] == 'U' and data[start+2] == 'T':
       return some(HttpPut)
     if data[start+1] == 'A' and data[start+2] == 'T' and
-       data[start+3] == 'C' and data[start+3] == 'H':
+       data[start+3] == 'C' and data[start+4] == 'H':
       return some(HttpPatch)
   of 'D':
     if data[start+1] == 'E' and data[start+2] == 'L' and


### PR DESCRIPTION
I was trying to define a route to handle PATCH requests in Jester but the requests kept returning 501 Not Implemented. My search led me here where I noticed this typo. After making this fix, PATCH requests are correctly identified and passed on to Jester again.