### PR TITLE
Switch back to original asynctools

### DIFF
--- a/httpbeast.nimble
+++ b/httpbeast.nimble
@@ -12,7 +12,7 @@ srcDir = "src"
 requires "nim >= 0.18.0"
 
 # Test dependencies
-requires "https://github.com/timotheecour/asynctools#pr_fix_compilation"
+requires "asynctools"
 
 task helloworld, "Compiles and executes the hello world server.":
   exec "nim c -d:release --gc:boehm -r tests/helloworld"


### PR DESCRIPTION
This was merged: https://github.com/cheatfate/asynctools/pull/18 so it's safe to switch back to original asynctools