### PR TITLE
Tolerate EMFILE (Too many open files)

### DIFF
--- a/src/httpbeast.nim
+++ b/src/httpbeast.nim
@@ -71,7 +71,7 @@ template handleAccept() =
     let lastError = osLastError()
 
     if lastError.int32 == EMFILE:
-      echo osErrorMsg(lastError)
+      warn("Ignoring EMFILE error: ", osErrorMsg(lastError))
       return
 
     raiseOSError(lastError)

--- a/src/httpbeast.nim
+++ b/src/httpbeast.nim
@@ -1,4 +1,4 @@
-import selectors, net, nativesockets, os, httpcore, asyncdispatch, strutils
+import selectors, net, nativesockets, os, httpcore, asyncdispatch, strutils, posix
 import parseutils
 import options, future, logging
 
@@ -69,6 +69,11 @@ template handleAccept() =
   let (client, address) = fd.SocketHandle.accept()
   if client == osInvalidSocket:
     let lastError = osLastError()
+
+    if lastError.int32 == EMFILE:
+      echo osErrorMsg(lastError)
+      return
+
     raiseOSError(lastError)
   setBlocking(client, false)
   selector.registerHandle(client, {Event.Read},


### PR DESCRIPTION
httpbeast stops working when SocketHandle.accept() fails, but EMFILE (Too many open files) sometimes occurs when ulimit -n is not well optimized, and many concurrent requests are coming. Keep running in such a situation would be better than stopping.