### PR TITLE
Fix crosstalk

### DIFF
--- a/src/httpbeast.nim
+++ b/src/httpbeast.nim
@@ -96,8 +96,10 @@ template handleClientClosure(selector: Selector[Data],
   if completed:
     fd.SocketHandle.close()
 
-  when inLoop: break
-  else: return
+  when inLoop:
+    break
+  else:
+    return
 
 proc onRequestFutureComplete(theFut: Future[void],
                              selector: Selector[Data], fd: int) =
@@ -247,7 +249,8 @@ proc processEvents(selector: Selector[Data],
                       fd.int,
                       proc (fut: Future[void]; fd: int) =
                         onRequestFutureComplete(fut, selector, fd)
-                        validateResponse())
+                        validateResponse()
+                    )
                   else:
                     data.completed = true
                     validateResponse()


### PR DESCRIPTION
Fixes https://github.com/dom96/jester/issues/248

When a client disconnects, httpbeast immediately releases and then reuses file descriptors, even when the request future hasn't completed. Multiple requests will then be using the same file descriptors, resulting in crosstalk. To fix this, we keep track of whether the client has closed the connection, and whether the request has completed. The logic is a little hairy, but it took many hours of playing with edge cases to figure this out. The basic idea is as follows:

- Normal request where server responds with text and client closes after receiving up to content-length. In this case the timeline is:
  1. callback, not closed yet and sendQueue.len > 0, do nothing
  2. client closure, unregister file descriptor and close socket

- Request where client listens to server, server closes connection before the client.
  1. callback, not closed but sendQueue.len == 0, unregister file descriptor and close the socket since there is no more to send.
  2. the callback unregistered the fd, so there is no client closure event

- Same as above, except the client disconnects while listening, after which the server closes the connection:
  1. client closure, not completed so don't close socket, but fd is in selector, unregister to avoid 100% CPU from continuous read events (not sure why that happens though)
  2. callback, `data` is now nil since the file descriptor got unregistered, close the socket

Doing this we can effectively eliminate crosstalk and prevent sockets from not being released. The test suite passes and performance is the same.

While working on this I ran into a very weird bug that appears to be a race condition with how closures capture environments. The file descriptor passed into the callback was wrong in rare cases, being the one from the previous callback instead, causing sockets to get stalled. While troubleshooting I modified asyncfuture.addCallback to take a file descriptor argument and print it in the proc that wraps the callback, and even more weirdly that one is correct, while the callback called from the proc shows the wrong one. Based on that I made the custom `addCallback` function as a workaround, since passing the values to a proc before making the closure mitigates it. 