### PR TITLE
Register existent loggers to each thread

### DIFF
--- a/src/httpbeast.nim
+++ b/src/httpbeast.nim
@@ -46,6 +46,7 @@ type
     port*: Port
     bindAddr*: string
     numThreads: int
+    loggers: seq[Logger]
 
 const
   serverInfo = "HttpBeast"
@@ -53,10 +54,12 @@ const
 proc initSettings*(port: Port = Port(8080),
                    bindAddr: string = "",
                    numThreads: int = 0): Settings =
+
   Settings(
     port: port,
     bindAddr: bindAddr,
     numThreads: numThreads,
+    loggers: getHandlers()
   )
 
 proc initData(fdKind: FdKind, ip = ""): Data =
@@ -271,6 +274,9 @@ proc updateDate(fd: AsyncFD): bool =
 
 proc eventLoop(params: (OnRequest, Settings)) =
   let (onRequest, settings) = params
+
+  for logger in settings.loggers:
+    addHandler(logger)
 
   let selector = newSelector[Data]()
 

--- a/tests/simpleLog.nim
+++ b/tests/simpleLog.nim
@@ -1,0 +1,26 @@
+import logging
+import options, asyncdispatch
+
+import .. / src / httpbeast
+
+
+let logFile = open("tests/logFile.tmp", fmWrite)
+var fileLog = newFileLogger(logFile)
+addHandler(fileLog)
+
+proc onRequest(req: Request): Future[void] =
+  if req.httpMethod == some(HttpGet):
+    case req.path.get()
+    of "/":
+      info("Requested /")
+      flushFile(logFile)  # Only errors above lvlError auto-flush
+      req.send("Hello World")
+    else:
+      error("404")
+      req.send(Http404)
+
+block:
+  let settings = initSettings()
+
+  run(onRequest, settings)
+  logFile.close()


### PR DESCRIPTION
According to [docs](https://nim-lang.org/docs/logging.html#basic-usage-notes-when-using-multiple-threads), loggers must be registered to each thread.

Some user of Jester hit this on [2019](https://github.com/dom96/jester/issues/223), and I hit it a couple days ago.

This gets the registered handlers when creating the settings at `initSettings` and then register each handler in the `eventLoop`.

I'm creating and deleting a file in the tests to check the logging, as I was unable to catch the stdout.