### PR TITLE
skip buf initialization

### DIFF
--- a/src/httpbeast.nim
+++ b/src/httpbeast.nim
@@ -210,7 +210,7 @@ proc processEvents(selector: Selector[Data],
     of Client:
       if Event.Read in events[i].events:
         const size = 256
-        var buf: array[size, char]
+        var buf {.noinit.}: array[size, char]
         # Read until EAGAIN. We take advantage of the fact that the client
         # will wait for a response after they send a request. So we can
         # comfortably continue reading until the message ends with \c\l


### PR DESCRIPTION
Since later on, only the bytes that were written into `buf` are read out.
https://github.com/dom96/httpbeast/blob/283e405c1e4a47265b1865638ed49b77b55bb7e5/src/httpbeast.nim#L204-L207