### PR TITLE
reusePort = false now default; honored regardless of numThreads

### DIFF
--- a/httpbeast.nimble
+++ b/httpbeast.nimble
@@ -1,6 +1,6 @@
 # Package
 
-version       = "0.4.0"
+version       = "0.4.1"
 author        = "Dominik Picheta"
 description   = "A super-fast epoll-backed and parallel HTTP server."
 license       = "MIT"


### PR DESCRIPTION
/cc @dom96 

## before PR
```
in terminal tab 1:
nim r --threads jester/tests/example.nim

in terminal tab 2:
nim r --threads jester/tests/example.nim # no failure
curl http://0.0.0.0:5000 # sends cmd to 1st server
```

## after PR
```
in terminal tab 1:
nim r --threads jester/tests/example.nim

in terminal tab 2:
nim r --threads jester/tests/example.nim # fails with: Address already in use
```


after this PR, https://github.com/dom96/jester/pull/278 can be merged which will allow forwarding `reusePort` param from jester to httpbeast and honor this flag

(see also https://github.com/nim-lang/Nim/pull/18428 which improves errmsg on nim side)