### PR TITLE
alternative to https://github.com/dom96/httpbeast/pull/50 using `failOnExistingPort`

### DIFF
--- a/httpbeast.nimble
+++ b/httpbeast.nimble
@@ -1,6 +1,6 @@
 # Package
 
-version       = "0.4.0"
+version       = "0.4.1"
 author        = "Dominik Picheta"
 description   = "A super-fast epoll-backed and parallel HTTP server."
 license       = "MIT"


### PR DESCRIPTION
alternative to https://github.com/dom96/httpbeast/pull/50

Note that I still consider https://github.com/dom96/httpbeast/pull/50 a better approach, as discussed here https://github.com/dom96/httpbeast/pull/50#discussion_r670042384 (it was cleaner and not subject to TOCTOU when numThreads=1 and pre-existing code already was ignoring `reusePort` in the case `when httpbeast`)

after this PR, https://github.com/dom96/jester/pull/281 should be merged to allow forwarding `jester.reusePort` as `httpbeast.failOnExistingPort`