### PR TITLE
replace `reusePort` by `failOnExistingPort`, simpler state (single bool), no TOCTOU for numThreads=1

### DIFF
--- a/httpbeast.nimble
+++ b/httpbeast.nimble
@@ -1,6 +1,6 @@
 # Package
 
-version       = "0.4.1"
+version       = "0.5.0"
 author        = "Dominik Picheta"
 description   = "A super-fast epoll-backed and parallel HTTP server."
 license       = "MIT"

--- a/httpbeast.nimble
+++ b/httpbeast.nimble
@@ -1,6 +1,6 @@
 # Package
 
-version       = "0.4.0"
+version       = "0.4.1"
 author        = "Dominik Picheta"
 description   = "A super-fast epoll-backed and parallel HTTP server."
 license       = "MIT"


### PR DESCRIPTION
should be followed by https://github.com/dom96/jester/pull/281 in jester

alternative to https://github.com/dom96/httpbeast/pull/50 and https://github.com/dom96/httpbeast/pull/52 that hits all the targets:
* jester can forward `jester.reusePort` as `httpbeast.failOnExistingPort` = `not reusePort`
* sane default (by default, fails with address already in use in all cases: stdlib's httpserver, jester without httpbeast, and jester with httpbeast)
* avoid redundant state with 2 bools (reusePort + failOnExistingPort) or a tri-state, instead there's a single bool flag
* avoids the concern raised in https://github.com/dom96/httpbeast/pull/50#discussion_r669996361 ("Yes, but you're doing that by ignoring the flag") since I'm now honoring `failOnExistingPort` inside httpbeast, it's consistent

The only downside is that this is a breaking change from the previous commit for client code that would've used thew new reusePort flag, but it was introduced very recently (10 days ago), and wasn't the commit I had signed up for, refs https://github.com/dom96/httpbeast/pull/47#issuecomment-873251880
> Sorry, I prefer for this stuff to be explicit. So I changed things.

so I've bumped the version to 0.5.0
(an alternative to this 10 day-window breaking change would be possible by adding a different `initSettings2` and deprecating `initSettings`, or simply define `initSettings` by interpreting the reusePort argument as `not failOnExistingPort`; but this software is pre-1.0 and it's only a 10-day window so IMO is acceptable)