### PR TITLE
 add a send overload

### DIFF
--- a/src/httpbeast.nim
+++ b/src/httpbeast.nim
@@ -397,7 +397,7 @@ proc send*(req: Request, code: HttpCode, body: string, contentLength: Option[str
     requestData.sendQueue.add(text)
   req.selector.updateHandle(req.client, {Event.Read, Event.Write})
 
-proc send*(req: Request, code: HttpCode, body: string, headers="") =
+proc send*(req: Request, code: HttpCode, body: string, headers = "") =
   ## Responds with the specified HttpCode and body.
   ##
   ## **Warning:** This can only be called once in the OnRequest callback.

--- a/src/httpbeast.nim
+++ b/src/httpbeast.nim
@@ -384,15 +384,15 @@ proc send*(req: Request, code: HttpCode, body: string, contentLength: Option[str
 
     let otherHeaders = if likely(headers.len == 0): "" else: "\c\L" & headers
 
-    let text = 
+    let length =
       if contentLength.isNone:
-        (
-          "HTTP/1.1 $#\c\LContent-Length: $#\c\LServer: $#\c\LDate: $#$#\c\L\c\L$#"
-        ) % [$code, $body.len, serverInfo, serverDate, otherHeaders, body]
+        $body.len
       else:
-        (
+        contentLength.get
+
+    let text = (
           "HTTP/1.1 $#\c\LContent-Length: $#\c\LServer: $#\c\LDate: $#$#\c\L\c\L$#"
-        ) % [$code, contentLength.get, serverInfo, serverDate, otherHeaders, body]
+        ) % [$code, length, serverInfo, serverDate, otherHeaders, body]
 
     requestData.sendQueue.add(text)
   req.selector.updateHandle(req.client, {Event.Read, Event.Write})


### PR DESCRIPTION
ref https://github.com/dom96/jester/issues/241

adding a way supporting user-defined `Content-Length` 

usage:
```nim
  if headers.hasKey("Content-Length"):
    request.send(code, body, some(headers["Content-Length", 0]), headers.createHeaders)
  else:
    request.send(code, body, headers.createHeaders)
```