### PR TITLE
Preallocate string size for performance

### DIFF
--- a/src/httpbeast.nim
+++ b/src/httpbeast.nim
@@ -397,7 +397,7 @@ proc send*(req: Request, code: HttpCode, body: string, headers="") =
       raise HttpBeastDefect(msg: "You are attempting to send data to a stale request.")
 
     let otherHeaders = if likely(headers.len == 0): "" else: "\c\L" & headers
-    var text = ""
+    var text = newStringOfCap(30 + body.len + serverInfo.len + serverDate.len + otherHeaders.len)
     text &= "HTTP/1.1 "
     text &= $code
     text &= "\c\LContent-Length: "


### PR DESCRIPTION
Inspired by #63. I noticed that a decent chunk of time is spent in string allocation, probably because each time we add onto the string past a certain limit Nim needs to reallocate it and get a bigger string. In this case, since we know the sizes of most of the things we are allocating we can simply preallocate the appoximate size of the buffer we'll need.

I used ~30 to refer to the number of bytes inside of the quotes. There's a bit of headroom there due to the HTTP code size in bytes, but it shouldn't actually affect performance all that much. This probably improved htppbeast performance on my machine by a few percent? 

This method for preallocating is about 25% faster than what we have there right now from that last PR though:
```nim
import benchy
import strutils

const serverInfo = "HttpBeast"
let 
  code = 200
  body = "hello world"
  serverDate = "02-20-2020"
  otherHeaders = ""

const reps = 100_000

timeIt "% formatting":
    for i in 0..reps:
      let text =  "HTTP/1.1 $#\c\L" & "Content-Length: $#\c\LServer: $#\c\LDate: $#$#\c\L\c\L$#" % [$code, $body.len, serverInfo, serverDate, otherHeaders, body]
      keep text

timeIt "concating":
  for i in 0..reps:
    var text = ""
    text &= "HTTP/1.1 "
    text &= $code
    text &= "\c\LContent-Length: "
    text &= $body.len
    text &= "\c\LServer: " & serverInfo
    text &= "\c\LDate: "
    text &= serverDate
    text &= otherHeaders
    text &= "\c\L\c\L"
    text &= body
    keep text

timeIt "smart concating":
  for i in 0..reps:
    var text = newStringOfCap(40 + body.len + serverInfo.len + serverDate.len + otherHeaders.len)
    text &= "HTTP/1.1 "
    text &= $code
    text &= "\c\LContent-Length: "
    text &= $body.len
    text &= "\c\LServer: " & serverInfo
    text &= "\c\LDate: "
    text &= serverDate
    text &= otherHeaders
    text &= "\c\L\c\L"
    text &= body
    keep text
```
```
name ............................... min time      avg time    std dv   runs
% formatting ...................... 44.926 ms     45.232 ms    ±0.264   x110
concating ......................... 19.794 ms     19.846 ms    ±0.029   x252
smart concating ................... 14.677 ms     14.833 ms    ±0.034   x337
```

