### PR TITLE
Decreases flakiness of certain tests

### DIFF
--- a/tests/simpleLog.nim
+++ b/tests/simpleLog.nim
@@ -16,6 +16,7 @@ proc onRequest(req: Request): Future[void] =
       flushFile(logFile)  # Only errors above lvlError auto-flush
       req.send("Hello World")
     else:
+      info("Requested ", req.path.get())
       error("404")
       req.send(Http404)
 

--- a/tests/tester.nim
+++ b/tests/tester.nim
@@ -86,11 +86,14 @@ proc tests() {.async.} =
     check resp.code == Http200
     check logFilename.readLines() == @["INFO Requested /"]
 
+  check tryRemoveFile(logFilename)
+  await startServer("simpleLog.nim")
+
   block:
     let client = newAsyncHttpClient()
     let resp = await client.get("http://localhost:8080/404")
     check resp.code == Http404
-    check logFilename.readLines(2) == @["INFO Requested /", "ERROR 404"]
+    check logFilename.readLines(2) == @["INFO Requested /404", "ERROR 404"]
 
   check tryRemoveFile(logFilename)
 

--- a/tests/tester.nim
+++ b/tests/tester.nim
@@ -118,6 +118,7 @@ proc tests() {.async.} =
     let delayedBody = await client.recv(10)
     doAssert(delayedBody == "Delayed /2", "We must get the ID we asked for.")
 
+  await startServer("crosstalk.nim")
   block:
     var client = newAsyncSocket()
     await client.connect("localhost", Port(8080))


### PR DESCRIPTION
I wasn't certain whether it's fine to restart the crosstalk server, but I double checked by reverting d45c7f9b421b6991982cf49cbae95a2e5bf09dd0 locally and verifying that the tests fail, so it definitely still works.