### PR TITLE
Remediating a previously reported DoS

### DIFF
--- a/src/httpbeast.nim
+++ b/src/httpbeast.nim
@@ -191,7 +191,6 @@ proc bodyInTransit(data: ptr Data): bool =
   var trueLen = parseContentLength(data.data, start=0)
 
   let bodyLen = data.data.len - data.headersFinishPos
-  assert(not (bodyLen > trueLen))
   return bodyLen != trueLen
 
 var requestCounter: uint = 0


### PR DESCRIPTION
Though seemingly small, this single line permits a CWE-617 DoS. With a single request, an attacker can bring down any httpbeast-reliant framework, including Jester.

The vulnerability was found during secure code review, then triaged a few months ago by @FedericoCeratto.