### PR TITLE
Fixes a bug where `data` is not captured correctly.

### DIFF
--- a/tests/delayed_writes.nim
+++ b/tests/delayed_writes.nim
@@ -1,0 +1,22 @@
+# Note: This test isn't part of the test suite, just here for reference.
+
+import options, asyncdispatch, random
+
+import httpbeast
+
+proc onRequest(req: Request): Future[void] =
+  var res = newFuture[void]()
+  if req.httpMethod == some(HttpGet):
+    case req.path.get()
+    of "/":
+      let sleepFut = sleepAsync(rand(2000))
+      sleepFut.callback =
+        proc () =
+          req.send("Hello World")
+          res.complete()
+    else:
+      req.send(Http404)
+      res.complete()
+  return res
+
+run(onRequest, initSettings(numThreads=1, port=Port(5000)))


### PR DESCRIPTION
Originally reported in: https://github.com/dom96/jester/issues/296. This took me longer to find than I'd like to admit. I did actually try `closureScope` first, but I think it didn't work because of the `template` that's here (even the `capture` has no effect on the contents of the template, which is why I changed it to take the `data` explicitly. This is quite a nasty gotcha in Nim).

**Test plan:**

``nim c -r tests/delayed_writes.nim``

``wrk -c 10 -t 1 -d 10 http://localhost:5000/``

Before:

```
Starting 1 threads
Listening on port 5000
SO_REUSEPORT not supported on this platform. HttpBeast will not utilise all threads.
/mnt/c/Users/morfe/projects/httpbeast/tests/delayed_writes.nim(22) delayed_writes
/mnt/c/Users/morfe/projects/httpbeast/src/httpbeast.nim(540) run
/mnt/c/Users/morfe/projects/httpbeast/src/httpbeast.nim(371) eventLoop
/mnt/c/Users/morfe/projects/httpbeast/src/httpbeast.nim(227) processEvents
/home/dom/.choosenim/toolchains/nim-1.6.6/lib/pure/asyncdispatch.nim(1653) poll
/home/dom/.choosenim/toolchains/nim-1.6.6/lib/pure/asyncdispatch.nim(1394) runOnce
/home/dom/.choosenim/toolchains/nim-1.6.6/lib/pure/asyncdispatch.nim(234) processPendingCallbacks
/mnt/c/Users/morfe/projects/httpbeast/tests/delayed_writes.nim(15) :anonymous
/mnt/c/Users/morfe/projects/httpbeast/src/httpbeast.nim(456) send
/mnt/c/Users/morfe/projects/httpbeast/src/httpbeast.nim(421) send
/home/dom/.choosenim/toolchains/nim-1.6.6/lib/system/assertions.nim(38) failedAssertImpl
/home/dom/.choosenim/toolchains/nim-1.6.6/lib/system/assertions.nim(28) raiseAssert
/home/dom/.choosenim/toolchains/nim-1.6.6/lib/system/fatal.nim(53) sysFatal
Error: unhandled exception: /mnt/c/Users/morfe/projects/httpbeast/src/httpbeast.nim(421, 12) `requestData.headersFinished` Selector not ready to send. [AssertionDefect]
```

After: *no crash*
