### PR TITLE
Make using custom headers easier/nicer

### DIFF
--- a/src/httpbeast.nim
+++ b/src/httpbeast.nim
@@ -477,6 +477,10 @@ proc send*(req: Request, body: string, code = Http200) {.inline.} =
   ## **Warning:** This can only be called once in the OnRequest callback.
   req.send(code, body)
 
+proc send*(req: Request, body: string, headers: string, code = Http200) =
+  ## Sends a HTTP 200 OK response with the specified body and headers.
+  req.send(code, body, headers)
+
 proc httpMethod*(req: Request): Option[HttpMethod] {.inline.} =
   ## Parses the request's data to find the request HttpMethod.
   parseHttpMethod(req.selector.getData(req.client).data, req.start)


### PR DESCRIPTION
With this commit you can go from having to write:
```
req.send(Http200, getTime().format("yyyy-MM-dd"), "Access-Control-Allow-Origin: *")
```

to writing:
```
req.send(getTime().format("yyyy-MM-dd"), "Access-Control-Allow-Origin: *")
```

It's a small change, but given [we already have something similar for sending a `body` with a custom `code`](https://github.com/dom96/httpbeast/blob/master/src/httpbeast.nim#L474)—very handy for when a custom response code is needed—to me it only makes sense we have one for custom headers, something that gets set far more often.

Sorry if this may be out of scope, I just found it a personal annoyance having to write `Http200, ` every time just because I needed a custom header.

Lastly, I do not know wether or not this should have the `{. inline .}` pragma or not.